### PR TITLE
Small doc improvements

### DIFF
--- a/docs/chrome_tracing.md
+++ b/docs/chrome_tracing.md
@@ -56,11 +56,11 @@ Let's zoom in a bit and look at the what's in the timegraph:
 
 ![Chrome Tracing Detail](images/chrome_tracing_detail.png)
 
-When the `ChromePerformanceTimingInStages flag is also set, the calls are
+When the `ChromePerformanceTimingInStages` flag is also set, the calls are
 further split into stages and reorganized; here is what that looks like on 
 a timegraph:
 
-![Chrome Tracing with Stages Detail](images/chrome_tracing_with_stages.png)
+![Chrome Tracing with Stages Detail](images/chrome_tracing_with_stages.PNG)
 
 ## Overhead
 


### PR DESCRIPTION
The picture does not load because it's PNG description is capitalized - adjust the document appropriately.

Fixes #

## Description of Changes
Changed the extension of the picture I added in the doc, and added a ` character where i missed one.
